### PR TITLE
Ergonomic improvements: into_inner, as_slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linear-map"
-version = "1.2.1"
+version = "1.2.2"
 license = "MIT/Apache-2.0"
 description = "A map implemented by searching linearly in a vector."
 authors = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ impl<K: Eq, V> LinearMap<K, V> {
 
     /// Returns the given key's corresponding entry in the map for in-place manipulation.
     pub fn entry(&mut self, key: K) -> Entry<K, V> {
-        match self.storage.iter().position(|&(ref k, _)| key == *k) {
+        match self.storage.iter().position(|(k, _)| key == *k) {
             None => Vacant(VacantEntry { map: self, key }),
             Some(index) => Occupied(OccupiedEntry { map: self, index }),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,11 @@ impl<K: Eq, V> LinearMap<K, V> {
         Values { iter: self.iter() }
     }
 
+    /// Consumes the container and yields the internal vector storage.
+    pub fn into_inner(self) -> Vec<(K, V)> {
+        self.storage
+    }
+
     /// Returns a reference to the value in the map whose key is equal to the given key.
     ///
     /// Returns `None` if the map contains no such key.

--- a/src/set.rs
+++ b/src/set.rs
@@ -533,6 +533,21 @@ where
     pub fn as_slice(&self) -> &[(T, ())] {
         &self.map.storage
     }
+
+    /// Returns a a slice viewing the sets values in arbitrary order.
+    ///
+    /// The item type is `(T, ())`.
+    ///```
+    /// let items = (0..5u8).filter(|x| x % 2 == 1).collect::<linear_map::set::LinearSet<u8>>();
+    /// assert_eq!(items.as_slice_unsafe(), &[1, 3u8]);
+    ///```
+    /// Since (T, ()) has the same size as T, we can cast it without breaking things.
+    /// However, this requires an unsafe block.
+    pub fn as_slice_unsafe(&self) -> &[T] {
+        let data = self.map.storage.as_ptr().cast::<T>();
+        let len = self.map.storage.len();
+        unsafe { std::slice::from_raw_parts(data, len) }
+    }
 }
 
 impl<T> PartialEq for LinearSet<T>

--- a/src/set.rs
+++ b/src/set.rs
@@ -518,11 +518,7 @@ where
     T: Eq,
 {
     fn eq(&self, other: &LinearSet<T>) -> bool {
-        if self.len() != other.len() {
-            return false;
-        }
-
-        self.iter().all(|key| other.contains(key))
+        self.len() == other.len() && self.iter().all(|key| other.contains(key))
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -110,6 +110,19 @@ impl<T: Eq> LinearSet<T> {
             .into_iter()
             .map(|x| x.0)
             .collect::<Vec<_>>()
+        /*
+        unsafe {Vec::from_raw_parts(self.map.storage.data.as_mut_ptr().cast::<i32>(), self.map.storage.data.len(), self.map.storage.data.capacity())}}
+        */
+    }
+
+    /// Consumes the container and yields the internal vector storage.
+    /// No overhead/faster option compared to into_inner, but unsafe.
+    pub unsafe fn into_inner_unsafe(mut self) -> Vec<T> {
+        Vec::from_raw_parts(
+            self.map.storage.as_mut_ptr().cast::<T>(),
+            self.map.storage.len(),
+            self.map.storage.capacity(),
+        )
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -102,6 +102,15 @@ impl<T: Eq> LinearSet<T> {
             map: LinearMap::with_capacity(capacity),
         }
     }
+
+    /// Consumes the container and yields the internal vector storage.
+    pub fn into_inner(self) -> Vec<T> {
+        self.map
+            .storage
+            .into_iter()
+            .map(|x| x.0)
+            .collect::<Vec<_>>()
+    }
 }
 
 impl<T> LinearSet<T>

--- a/src/set.rs
+++ b/src/set.rs
@@ -117,12 +117,18 @@ impl<T: Eq> LinearSet<T> {
 
     /// Consumes the container and yields the internal vector storage.
     /// No overhead/faster option compared to into_inner, but unsafe.
-    pub unsafe fn into_inner_unsafe(mut self) -> Vec<T> {
-        Vec::from_raw_parts(
-            self.map.storage.as_mut_ptr().cast::<T>(),
-            self.map.storage.len(),
-            self.map.storage.capacity(),
-        )
+    ///
+    /// # Safety
+    /// This function should be safe; it simply requires an unsafe block.
+    /// It should yield identical results to into_inner, but without an additional memory allocation + copy.
+    pub fn into_inner_unsafe(mut self) -> Vec<T> {
+        unsafe {
+            Vec::from_raw_parts(
+                self.map.storage.as_mut_ptr().cast::<T>(),
+                self.map.storage.len(),
+                self.map.storage.capacity(),
+            )
+        }
     }
 }
 

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -267,7 +267,7 @@ fn test_drain() {
             assert_eq!(last_i, 49);
         }
 
-        for _ in &s {
+        if (&s).into_iter().next().is_some() {
             panic!("s should be empty!");
         }
 


### PR DESCRIPTION
1. Add `into_inner` functions for set + map.
2. Add `as_slice_unsafe` for set, which gives a slice into the set without the trailing `()`.
3. Bump to 1.2.2.